### PR TITLE
Query normalization

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "babel-plugin-inline-package-json": "^2.0.0",
     "babel-preset-es2015": "^6.13.2",
     "chai": "^3.5.0",
+    "graphql-tag": "^0.1.14",
     "mocha": "^3.0.2"
   },
   "peerDependencies": {

--- a/src/Normalize.js
+++ b/src/Normalize.js
@@ -18,10 +18,11 @@ export const normalizeQuery = (info) => {
     definitions: [
       info.operation,
       ...Object.keys(info.fragments).map(k => info.fragments[k]),
-    ],
-  }
+    ]
+  };
 
-  const prunedAST = separateOperations(doc)[info.operation.name.value];
+  const prunedAST = separateOperations(doc)[
+    (info.operation.name && info.operation.name.value) || ''];
 
   return print(prunedAST);
 };

--- a/src/Normalize.js
+++ b/src/Normalize.js
@@ -1,8 +1,10 @@
 // This file contains helper functions to format or normalize data.
 
 import { GraphQLList, GraphQLNonNull }  from 'graphql/type';
+import { separateOperations } from 'graphql/utilities';
 
 import { print } from './normalizedPrinter';
+
 
 
 ////////// GraphQL //////////
@@ -11,13 +13,17 @@ import { print } from './normalizedPrinter';
 // https://github.com/apollostack/optics-agent/blob/master/docs/signatures.md
 // for details.
 export const normalizeQuery = (info) => {
-  // XXX implement
+  const doc = {
+    kind: 'Document',
+    definitions: [
+      info.operation,
+      ...Object.keys(info.fragments).map(k => info.fragments[k]),
+    ],
+  }
 
-  const operation = print(info.operation);
-  const fragments = Object.keys(info.fragments).map(k => print(info.fragments[k])).join('\n');
-  const fullQuery = `${operation}\n${fragments}`;
+  const prunedAST = separateOperations(doc)[info.operation.name.value];
 
-  return fullQuery;
+  return print(prunedAST);
 };
 
 

--- a/src/Normalize.js
+++ b/src/Normalize.js
@@ -1,7 +1,7 @@
 // This file contains helper functions to format or normalize data.
 
 import { GraphQLList, GraphQLNonNull }  from 'graphql/type';
-import { separateOperations } from 'graphql/utilities';
+import { separateOperations } from './separateOperations';
 
 import { print } from './normalizedPrinter';
 

--- a/src/Normalize.test.js
+++ b/src/Normalize.test.js
@@ -7,9 +7,13 @@ import { normalizeQuery } from './Normalize';
 const testQueries = [
   [
     'basic test',
-    gql`query Foo {
-      user(name: "hello") {
+    gql`query Foo ($b: Int, $a: Boolean){
+      user(name: "hello", age: 5) {
         ... Bar
+        ... on User {
+          hello
+          bee
+        }
         tz
         aliased: name
       }
@@ -18,13 +22,14 @@ const testQueries = [
       asd
     }
     fragment Bar on User {
-      age
+      age @skip(if: $a)
       ...Nested
     }
     fragment Nested on User {
       blah
     }`,
-    'query Foo{user(name:"") {name tz ...Bar}}fragment Bar on User{age ...Nested}fragment Nested on User{blah}',
+    'query Foo($a:Boolean,$b:Int) {user(age:0, name:"") {... on User {bee hello} ...Bar name tz}}' +
+    ' fragment Bar on User {...Nested age @skip(if:$a)} fragment Nested on User {blah}',
   ],
 ];
 
@@ -45,7 +50,9 @@ describe('normalizeQuery', () => {
         operation,
         fragments,
       };
-      assert.equal(normalizeQuery(fakeInfo), outString, 'normalize');
+      const normalized = normalizeQuery(fakeInfo);
+      // console.log(normalized);
+      assert.equal(normalized, outString, 'normalize');
     });
   });
 });

--- a/src/Normalize.test.js
+++ b/src/Normalize.test.js
@@ -7,6 +7,33 @@ import { normalizeQuery } from './Normalize';
 const testQueries = [
   [
     'basic test',
+    gql`{
+      user {
+        name
+      }
+    }`,
+    '{user {name}}',
+  ],
+  [
+    'basic test with query',
+    gql`query {
+      user {
+        name
+      }
+    }`,
+    '{user {name}}',
+  ],
+  [
+    'basic with operation name',
+    gql`query OpName {
+      user {
+        name
+      }
+    }`,
+    'query OpName {user {name}}',
+  ],
+  [
+    'full test',
     gql`query Foo ($b: Int, $a: Boolean){
       user(name: "hello", age: 5) {
         ... Bar

--- a/src/Normalize.test.js
+++ b/src/Normalize.test.js
@@ -1,18 +1,51 @@
 import { assert } from 'chai';
+import gql from 'graphql-tag';
 
 import { normalizeQuery } from './Normalize';
 
 
 const testQueries = [
-  // XXX construct info operations
-  // [
-    
-  // ]
+  [
+    'basic test',
+    gql`query Foo {
+      user(name: "hello") {
+        ... Bar
+        tz
+        aliased: name
+      }
+    }
+    fragment Baz on User {
+      asd
+    }
+    fragment Bar on User {
+      age
+      ...Nested
+    }
+    fragment Nested on User {
+      blah
+    }`,
+    'query Foo{user(name:"") {name tz ...Bar}}fragment Bar on User{age ...Nested}fragment Nested on User{blah}',
+  ],
 ];
 
 describe('normalizeQuery', () => {
-  testQueries.map(([info, outString],i) => {
-    it(''+i, () =>
-       assert.equal(outString, normalizeQuery(info), 'normalize'));
+  testQueries.map(([testName, inputDocument, outString],i) => {
+    it(testName, () => {
+      const fragments = {};
+      let operation = null;
+      inputDocument.definitions.forEach( def => {
+        if (def.kind === 'OperationDefinition'){
+          operation = def;
+        }
+        if (def.kind === 'FragmentDefinition'){
+          fragments[def.name.value] = def;
+        }
+      });
+      const fakeInfo = {
+        operation,
+        fragments,
+      };
+      assert.equal(normalizeQuery(fakeInfo), outString, 'normalize');
+    });
   });
 });

--- a/src/Normalize.test.js
+++ b/src/Normalize.test.js
@@ -33,6 +33,22 @@ const testQueries = [
     'query OpName {user {name}}',
   ],
   [
+    'fragment',
+    gql`{
+      user {
+        name
+        ...Bar
+      }
+    }
+    fragment Bar on User {
+      asd
+    }
+    fragment Baz on User {
+      jkl
+    }`,
+    '{user {name ...Bar}} fragment Bar on User {asd}',
+  ],
+  [
     'full test',
     gql`query Foo ($b: Int, $a: Boolean){
       user(name: "hello", age: 5) {
@@ -55,8 +71,8 @@ const testQueries = [
     fragment Nested on User {
       blah
     }`,
-    'query Foo($a:Boolean,$b:Int) {user(age:0, name:"") {... on User {bee hello} ...Bar name tz}}' +
-    ' fragment Bar on User {...Nested age @skip(if:$a)} fragment Nested on User {blah}',
+    'query Foo($a:Boolean,$b:Int) {user(age:0, name:"") {name tz ...Bar ... on User {bee hello}}}' +
+    ' fragment Bar on User {age @skip(if:$a) ...Nested} fragment Nested on User {blah}',
   ],
 ];
 

--- a/src/normalizedPrinter.js
+++ b/src/normalizedPrinter.js
@@ -28,12 +28,12 @@ const printDocASTReducer = {
 
   // Document
 
-  Document: node => join(node.definitions, '\n\n') + '\n',
+  Document: node => join(node.definitions, ' '),
 
   OperationDefinition(node) {
     const op = node.operation;
     const name = node.name;
-    const varDefs = wrap('(', join(node.variableDefinitions, ', '), ')');
+    const varDefs = wrap('(', join(node.variableDefinitions && node.variableDefinitions.sort(), ','), ')');
     const directives = join(node.directives, ' ');
     const selectionSet = node.selectionSet;
     // Anonymous queries with no directives or variable definitions can use
@@ -44,52 +44,52 @@ const printDocASTReducer = {
   },
 
   VariableDefinition: ({ variable, type, defaultValue }) =>
-    variable + ': ' + type + wrap(' = ', defaultValue),
+    variable + ':' + type + wrap(' = ', defaultValue),
 
-  SelectionSet: ({ selections }) => block(selections),
+  SelectionSet: ({ selections }) => block(selections && selections.sort()),
 
   Field: ({ alias, name, arguments: args, directives, selectionSet }) =>
     join([
-      wrap('', alias, ': ') + name + wrap('(', join(args, ', '), ')'),
+      /* wrap('', alias, ':') + */ name + wrap('(', join(args && args.sort(), ', '), ')'),
       join(directives, ' '),
       selectionSet
     ], ' '),
 
-  Argument: ({ name, value }) => name + ': ' + value,
+  Argument: ({ name, value }) => name + ':' + value,
 
   // Fragments
 
   FragmentSpread: ({ name, directives }) =>
-    '...' + name + wrap(' ', join(directives, ' ')),
+    '...' + name + wrap(' ', join(directives && directives.sort(), ' ')),
 
   InlineFragment: ({ typeCondition, directives, selectionSet }) =>
     join([
       '...',
       wrap('on ', typeCondition),
-      join(directives, ' '),
+      join(directives && directives.sort(), ' '),
       selectionSet
     ], ' '),
 
   FragmentDefinition: ({ name, typeCondition, directives, selectionSet }) =>
     `fragment ${name} on ${typeCondition} ` +
-    wrap('', join(directives, ' '), ' ') +
+    wrap('', join(directives && directives.sort(), ' '), ' ') +
     selectionSet,
 
   // Value
 
-  IntValue: ({ value }) => 0, // OPTICS
-  FloatValue: ({ value }) => 0, // OPTICS
-  StringValue: ({ value }) => '""', // OPTICS
+  IntValue: ({ value }) => 0,
+  FloatValue: ({ value }) => 0,
+  StringValue: ({ value }) => '""',
   BooleanValue: ({ value }) => JSON.stringify(value),
   EnumValue: ({ value }) => value,
-  ListValue: ({ values }) => '[' + join(values, ', ') + ']',
-  ObjectValue: ({ fields }) => '{' + join(fields, ', ') + '}',
+  ListValue: ({ values }) => '[]',
+  ObjectValue: ({ fields }) => '{}',
   ObjectField: ({ name, value }) => name + ': ' + value,
 
   // Directive
 
   Directive: ({ name, arguments: args }) =>
-    '@' + name + wrap('(', join(args, ', '), ')'),
+    '@' + name + wrap('(', join(args && args.sort(), ','), ')'),
 
   // Type
 
@@ -107,7 +107,7 @@ const printDocASTReducer = {
     ], ' '),
 
   OperationTypeDefinition: ({ operation, type }) =>
-    operation + ': ' + type,
+    operation + ':' + type,
 
   ScalarTypeDefinition: ({ name, directives }) =>
     join([ 'scalar', name, join(directives, ' ') ], ' '),
@@ -123,13 +123,13 @@ const printDocASTReducer = {
 
   FieldDefinition: ({ name, arguments: args, type, directives }) =>
     name +
-    wrap('(', join(args, ', '), ')') +
-    ': ' + type +
+    wrap('(', join(args, ','), ')') +
+    ':' + type +
     wrap(' ', join(directives, ' ')),
 
   InputValueDefinition: ({ name, type, defaultValue, directives }) =>
     join([
-      name + ': ' + type,
+      name + ':' + type,
       wrap('= ', defaultValue),
       join(directives, ' ')
     ], ' '),
@@ -190,7 +190,7 @@ function join(maybeArray, separator) {
  */
 function block(array) {
   return array && array.length !== 0 ?
-    indent('{\n' + join(array, '\n')) + '\n}' :
+    indent('{' + join(array, ' ')) + '}' :
     '{}';
 }
 

--- a/src/separateOperations.js
+++ b/src/separateOperations.js
@@ -1,0 +1,95 @@
+// This code taken and adapted from:
+// https://raw.githubusercontent.com/graphql/graphql-js/c614f759df5e436b1092af53811311b254ebb189/src/utilities/separateOperations.js
+// according to the term of the BSD-style license provided there and copied below
+
+// This is copied from graphql-js 0.7 so that optics can rely on it
+// being available even when used with a graphql-js 0.6 server.
+
+/* @flow */
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import { visit } from 'graphql/language';
+import {
+  Document,
+  OperationDefinition,
+} from 'graphql/language/ast';
+
+/**
+ * separateOperations accepts a single AST document which may contain many
+ * operations and fragments and returns a collection of AST documents each of
+ * which contains a single operation as well the fragment definitions it
+ * refers to.
+ */
+export function separateOperations(
+  documentAST
+) {
+
+  const operations = [];
+  const depGraph = Object.create(null);
+  let fromName;
+
+  // Populate the list of operations and build a dependency graph.
+  visit(documentAST, {
+    OperationDefinition(node) {
+      operations.push(node);
+      fromName = opName(node);
+    },
+    FragmentDefinition(node) {
+      fromName = node.name.value;
+    },
+    FragmentSpread(node) {
+      const toName = node.name.value;
+      (depGraph[fromName] ||
+        (depGraph[fromName] = Object.create(null)))[toName] = true;
+    }
+  });
+
+  // For each operation, produce a new synthesized AST which includes only what
+  // is necessary for completing that operation.
+  const separatedDocumentASTs = Object.create(null);
+  operations.forEach(operation => {
+    const operationName = opName(operation);
+    const dependencies = Object.create(null);
+    collectTransitiveDependencies(dependencies, depGraph, operationName);
+
+    separatedDocumentASTs[operationName] = {
+      kind: 'Document',
+      definitions: documentAST.definitions.filter(def =>
+        def === operation ||
+        def.kind === 'FragmentDefinition' && dependencies[def.name.value]
+      )
+    };
+  });
+
+  return separatedDocumentASTs;
+}
+
+// Provides the empty string for anonymous operations.
+function opName(operation) {
+  return operation.name ? operation.name.value : '';
+}
+
+// From a dependency graph, collects a list of transitive dependencies by
+// recursing through a dependency graph.
+function collectTransitiveDependencies(
+  collected,
+  depGraph,
+  fromName
+) {
+  const immediateDeps = depGraph[fromName];
+  if (immediateDeps) {
+    Object.keys(immediateDeps).forEach(toName => {
+      if (!collected[toName]) {
+        collected[toName] = true;
+        collectTransitiveDependencies(collected, depGraph, toName);
+      }
+    });
+  }
+}


### PR DESCRIPTION
Not exactly according to spec:

- Didn't quite remove all redundant whitespace
- ~~Sort order for inline fragments, fragment spreads and fields is reversed~~


Notes:

- Removing aliases may produce invalid queries