### PR TITLE
Code review for Report.js

### DIFF
--- a/src/Agent.js
+++ b/src/Agent.js
@@ -18,7 +18,7 @@ import {
 
 import {
   reportSchema,
-  sendReport,
+  sendStatsReport,
 } from './Report';
 
 export default class Agent {
@@ -72,7 +72,7 @@ export default class Agent {
     // https://github.com/apollostack/optics-agent-js/issues/4 we may
     // want to make this more complicated than just setInterval.
     // XXX there's no way to stop this interval (eg, for tests)
-    this.reportTimer = setInterval(() => { this.sendReport(); },
+    this.reportTimer = setInterval(() => { this.sendStatsReport(); },
                                    this.reportIntervalMs);
   }
 
@@ -108,7 +108,7 @@ export default class Agent {
 
   // XXX This is not part of the public API.
   //     https://github.com/apollostack/optics-agent-js/issues/51
-  sendReport() {
+  sendStatsReport() {
     if (!this.schema) {
       this.debugFn('Optics agent: schema not instrumented. Make sure to call `instrumentSchema`.');
       return;
@@ -122,6 +122,6 @@ export default class Agent {
     this.reportStartTime = +new Date();
     this.pendingResults = {};
     // actually send
-    sendReport(this, reportData, oldStartTime, this.reportStartTime, durationHr);
+    sendStatsReport(this, reportData, oldStartTime, this.reportStartTime, durationHr);
   }
 }

--- a/src/Report.js
+++ b/src/Report.js
@@ -55,6 +55,13 @@ export const getTypesFromSchema = (schema) => {
     t.name = typeName;
     t.field = [];
     const fields = type.getFields();
+
+    // XXX In general I'm confused by why `Object.keys(X).forEach` is the most
+    // common iteration idiom. It constructs a new array for the keys each time!
+    // Surely that's not the best recommended pattern these days, is it? I guess
+    // there's "use `Object.create(null)` instead of `{}` and happily use
+    // for/in", or there's "use Map instead". Maybe I don't know what I'm
+    // talking about though.
     Object.keys(fields).forEach((fieldName) => {
       const field = fields[fieldName];
       const f = new Field();
@@ -80,15 +87,17 @@ export const getTypesFromSchema = (schema) => {
 // system boot) is not a good idea.
 const durationHrTimeToNanos = hrtime => ((hrtime[0] * 1e9) + hrtime[1]);
 
+// Converts a JS Date into a Proto.Timestamp.
+const dateToTimestamp = date => new Timestamp(
+  { seconds: (date / 1000), nanos: (date % 1000) * 1e6 });
+
 // //////// Sending Data ////////
 
 export const sendMessage = (agent, path, message) => {
   const headers = {
     'user-agent': 'optics-agent-js',
+    'x-api-key': agent.apiKey,
   };
-  if (agent.apiKey) {
-    headers['x-api-key'] = agent.apiKey;
-  }
 
   const options = {
     url: agent.endpointUrl + path,
@@ -114,16 +123,15 @@ export const sendMessage = (agent, path, message) => {
 
 //  //////// Marshalling Data ////////
 
-export const sendReport = (agent, reportData, startTime, endTime, durationHr) => {
+export const sendStatsReport = (agent, reportData, startTime, endTime, durationHr) => {
   try {
     // build report protobuf object
     const report = new StatsReport();
     report.header = REPORT_HEADER;
 
-    report.start_time = new Timestamp(
-      { seconds: (endTime / 1000), nanos: (endTime % 1000) * 1e6 });
-    report.end_time = new Timestamp(
-      { seconds: (startTime / 1000), nanos: (startTime % 1000) * 1e6 });
+    report.start_time = dateToTimestamp(startTime);
+    report.end_time = dateToTimestamp(endTime);
+    // XXX Would be nice to rename this field to include the unit (ns).
     report.realtime_duration = durationHrTimeToNanos(durationHr);
 
     report.type = getTypesFromSchema(agent.schema);
@@ -186,19 +194,16 @@ export const sendTrace = (agent, context, info, resolvers) => {
 
     const trace = new Trace();
     // XXX make up a server_id
-    trace.start_time = new Timestamp(
-      { seconds: (context.startWallTime / 1000),
-        nanos: (context.startWallTime % 1000) * 1e6 });
-    trace.end_time = new Timestamp(
-      { seconds: (context.endWallTime / 1000),
-        nanos: (context.endWallTime % 1000) * 1e6 });
+    trace.start_time = dateToTimestamp(context.startWallTime);
+    trace.end_time = dateToTimestamp(context.endWallTime);
     trace.duration_ns = durationHrTimeToNanos(context.durationHrTime);
 
     trace.signature = agent.normalizeQuery(info);
 
     trace.details = new Trace.Details();
     const operationStr = print(info.operation);
-    const fragmentsStr = Object.keys(info.fragments).map(k => print(info.fragments[k])).join('\n');
+    const fragmentsStr = Object.keys(info.fragments).map(
+      k => `${print(info.fragments[k])}\n`).join('');
     trace.details.raw_query = `${operationStr}\n${fragmentsStr}`;
     if (info.operation.name) {
       trace.details.operation_name = print(info.operation.name);
@@ -220,6 +225,8 @@ export const sendTrace = (agent, context, info, resolvers) => {
     trace.http.path = req.url;
 
     trace.execute = new Trace.Node();
+    // XXX trace.execute.start_time is missing despite it being documented as
+    // non-(optional).
     trace.execute.child = resolvers.map((rep) => {
       // XXX for now we just list all the resolvers in a flat list.
       //
@@ -475,12 +482,14 @@ export const reportRequestEnd = (req) => {
             perClient: {},
             perField: {},
           };
-        }
 
-        // fill out per field if we haven't already for this query shape.
-        const perField = res[query].perField;
-        if (Object.keys(perField).length === 0) {
+          const perField = res[query].perField;
           const typeInfo = new TypeInfo(agent.schema);
+          // XXX Is this a slow operation, that we might end up performing once
+          // per minute? Is it worth keeping around an LRU cache from query to
+          // this shape? My guess is no, but just want an answer and I'll
+          // happily delete this comment if you agree that it's fast enough that
+          // once per minute per query is fine.
           visit(info.operation, visitWithTypeInfo(typeInfo, {
             Field: () => {
               const parentType = typeInfo.getParentType().name;
@@ -549,9 +558,11 @@ export const reportRequestEnd = (req) => {
         });
 
 
-        // check to see if we've sent a trace for this bucket yet this
-        // report period. if we haven't (ie, if we're the only query in
+        // check to see if we've sent a trace for this bucket/client name yet
+        // this report period. if we haven't (ie, if we're the only query in
         // this bucket), send one now.
+        // XXX would it also make sense to send traces for strange buckets of
+        //     individual resolvers?
         const bucket = latencyBucket(nanos);
         const numSoFar = clientObj.latencyBuckets[bucket];
         if (numSoFar === 1 && agent.reportTraces) {

--- a/src/Report.js
+++ b/src/Report.js
@@ -55,13 +55,6 @@ export const getTypesFromSchema = (schema) => {
     t.name = typeName;
     t.field = [];
     const fields = type.getFields();
-
-    // XXX In general I'm confused by why `Object.keys(X).forEach` is the most
-    // common iteration idiom. It constructs a new array for the keys each time!
-    // Surely that's not the best recommended pattern these days, is it? I guess
-    // there's "use `Object.create(null)` instead of `{}` and happily use
-    // for/in", or there's "use Map instead". Maybe I don't know what I'm
-    // talking about though.
     Object.keys(fields).forEach((fieldName) => {
       const field = fields[fieldName];
       const f = new Field();
@@ -485,11 +478,10 @@ export const reportRequestEnd = (req) => {
 
           const perField = res[query].perField;
           const typeInfo = new TypeInfo(agent.schema);
-          // XXX Is this a slow operation, that we might end up performing once
-          // per minute? Is it worth keeping around an LRU cache from query to
-          // this shape? My guess is no, but just want an answer and I'll
-          // happily delete this comment if you agree that it's fast enough that
-          // once per minute per query is fine.
+          // We do this calculation once per minute per query. We think this
+          // will be fast enough in most cases, and is out of critical path, but
+          // if profiling points at a slow spot here consider a cache -- the
+          // data is very cachable.
           visit(info.operation, visitWithTypeInfo(typeInfo, {
             Field: () => {
               const parentType = typeInfo.getParentType().name;


### PR DESCRIPTION
- Rename sendReport to sendStatsReport, as there are three kinds of
  reports and this function just does one of them.
- Introduce dateToTimestamp helper.
- Send x-api-key header unconditionally, as the agent is now disabled
  without one.
- Send correct values for StatsReport.start_time/end_time.
- For consistency, always end raw_query with a newline, instead of
  ending it with a newline iff there are no fragments. (I'm assuming
  here that the print() return values never end in newline, which
  seems to be correct from reading the code, but I haven't tried it.)
- Simplify conditional around calculating query type info, and possibly
  avoid doing it too often if a query has no fields somehow.
- Tweak a few comments.
- Ask a few questions of the code reviewer.